### PR TITLE
Aduana links skeleton

### DIFF
--- a/aduana_enlaces/index.html
+++ b/aduana_enlaces/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Enlaces Aduana Chile</title>
+    <!-- Tailwind CSS via CDN -->
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-gray-100 font-sans text-gray-900">
+    <!-- Navegación principal -->
+    <header class="bg-white shadow">
+        <nav class="container mx-auto flex items-center justify-between px-4 py-4">
+            <h1 class="text-xl font-semibold text-blue-900">Aduana Chile</h1>
+            <!-- Buscador accesible -->
+            <input id="search" type="text" placeholder="Buscar enlace" aria-label="Buscar enlaces" class="border rounded px-2 py-1 w-full max-w-xs" />
+        </nav>
+    </header>
+
+    <main class="container mx-auto p-4">
+        <!-- Contenedor para los enlaces agrupados -->
+        <div id="link-groups" class="space-y-8">
+            <!-- El contenido se insertará dinámicamente con JavaScript -->
+        </div>
+    </main>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/aduana_enlaces/scraper_aduana.json
+++ b/aduana_enlaces/scraper_aduana.json
@@ -1,0 +1,38 @@
+[
+    {
+        "title": "Franquicia de Viajeros",
+        "url": "https://www.aduana.cl/franquicia-del-viajero/aduana/2006-02-21/112939.html",
+        "description": "Información sobre franquicias para personas que ingresan al país",
+        "category": "Franquicias"
+    },
+    {
+        "title": "Trámites y Servicios en Línea",
+        "url": "https://www.aduana.cl/tramites-y-servicios-en-linea/aduana/2006-02-21/112939.html",
+        "description": "Portal de trámites digitales relacionados con Aduana",
+        "category": "Trámites"
+    },
+    {
+        "title": "Consultas de Valoración",
+        "url": "https://www.aduana.cl/consultas-de-valoracion/aduana/2009-04-09/135236.html",
+        "description": "Sistema para consultas de valoración de mercancías",
+        "category": "Consultas"
+    },
+    {
+        "title": "Normativa Aduanera Vigente",
+        "url": "https://www.aduana.cl/normativa-vigente/aduana/2006-02-21/112940.html",
+        "description": "Listado actualizado de normativas y leyes aplicables",
+        "category": "Normativas"
+    },
+    {
+        "title": "Estadísticas de Comercio Exterior",
+        "url": "https://www.aduana.cl/estadisticas-de-comercio-exterior/aduana/2009-04-09/135235.html",
+        "description": "Datos y reportes de comercio exterior chileno",
+        "category": "Comercio Exterior"
+    },
+    {
+        "title": "Portal de Denuncias",
+        "url": "https://www.aduana.cl/portal-de-denuncias/aduana/2013-07-25/115713.html",
+        "description": "Herramienta en línea para realizar denuncias a la Aduana",
+        "category": "Consultas"
+    }
+]

--- a/aduana_enlaces/script.js
+++ b/aduana_enlaces/script.js
@@ -1,0 +1,96 @@
+// Carga y muestra los enlaces desde scraper_aduana.json
+// Este archivo puede ampliarse para manejar más funcionalidades.
+
+let linksData = [];
+
+// Obtener los datos y renderizar al inicio
+fetch('scraper_aduana.json')
+    .then(resp => resp.json())
+    .then(data => {
+        linksData = data;
+        renderLinks(linksData);
+    })
+    .catch(err => console.error('Error al cargar datos', err));
+
+/**
+ * Agrupa y dibuja los enlaces en el contenedor principal
+ * @param {Array} data - Lista de objetos con {title, url, description, category}
+ */
+function renderLinks(data) {
+    const container = document.getElementById('link-groups');
+    container.innerHTML = '';
+
+    // Agrupar por categoría
+    const groups = {};
+    data.forEach(item => {
+        const group = item.category || 'Otros';
+        if (!groups[group]) groups[group] = [];
+        groups[group].push(item);
+    });
+
+    // Crear estructura HTML
+    Object.keys(groups).forEach(group => {
+        const section = document.createElement('section');
+        section.className = 'group-section';
+
+        const title = document.createElement('h2');
+        title.className = 'text-lg font-bold mb-4';
+        title.textContent = group;
+        section.appendChild(title);
+
+        const ul = document.createElement('ul');
+        ul.className = 'space-y-2';
+
+        groups[group].forEach(link => {
+            const li = document.createElement('li');
+            const a = document.createElement('a');
+            a.href = link.url;
+            a.textContent = link.title;
+            a.className = 'text-blue-700 hover:underline focus:underline';
+            a.target = '_blank';
+            a.rel = 'noopener noreferrer';
+            a.setAttribute('aria-label', link.description || link.title);
+            li.appendChild(a);
+
+            if (link.description) {
+                const p = document.createElement('p');
+                p.textContent = link.description;
+                p.className = 'text-sm text-gray-600';
+                li.appendChild(p);
+            }
+
+            ul.appendChild(li);
+        });
+
+        section.appendChild(ul);
+        container.appendChild(section);
+    });
+}
+
+// Filtrar mientras se escribe
+const searchInput = document.getElementById('search');
+searchInput.addEventListener('input', e => {
+    const term = e.target.value.toLowerCase();
+    const filtered = linksData.filter(item =>
+        item.title.toLowerCase().includes(term) ||
+        (item.description && item.description.toLowerCase().includes(term))
+    );
+    renderLinks(filtered);
+    highlight(term);
+});
+
+/**
+ * Resalta la palabra buscada dentro del contenedor
+ */
+function highlight(term) {
+    const container = document.getElementById('link-groups');
+    if (!term) {
+        container.querySelectorAll('mark').forEach(m => m.replaceWith(m.textContent));
+        return;
+    }
+    const regex = new RegExp(`(${term})`, 'gi');
+    container.querySelectorAll('li').forEach(li => {
+        li.innerHTML = li.innerHTML.replace(/<mark>|<\/mark>/g, '');
+        li.innerHTML = li.innerHTML.replace(regex, '<mark>$1</mark>');
+    });
+}

--- a/aduana_enlaces/style.css
+++ b/aduana_enlaces/style.css
@@ -1,0 +1,24 @@
+/*
+ * Estilos adicionales para complementar Tailwind
+ * y mantener la identidad visual de Aduana Chile.
+ */
+
+:root {
+    /* Colores institucionales */
+    --blue: #003366;        /* Azul marino */
+    --light-gray: #f4f5f7;  /* Gris claro */
+}
+
+body {
+    background-color: var(--light-gray);
+}
+
+h1, h2 {
+    font-family: 'Helvetica Neue', Arial, sans-serif; /* Tipografía estándar */
+    color: var(--blue);
+}
+
+/* Ajustes para resaltar los resultados de búsqueda */
+mark {
+    background-color: #fff176; /* amarillo suave */
+}


### PR DESCRIPTION
## Summary
- add skeleton for new Aduana links mini-portal
- include Tailwind-based layout and search
- provide sample dataset and JS to load/filter data

## Testing
- `node --version`
- `node -e "console.log('json entries', require('./aduana_enlaces/scraper_aduana.json').length)"`


------
https://chatgpt.com/codex/tasks/task_e_68434871cd44832fa9387722134f3733